### PR TITLE
Updated config.yaml for OTel Collector Version 0.95.0+

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,10 @@
 receivers:
   otlp:
     protocols:
-      grpc:
       http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
 
   hostmetrics:
     collection_interval: 10s
@@ -37,22 +39,27 @@ processors:
     send_batch_size: 100
     timeout: 10s
 
+connectors:
+  datadog/connector: {}
+
 exporters:
-  datadog:
+  datadog/exporter:
     api:
       key: <YOUR_DD_API_KEY>
 
 service:
   pipelines:
     metrics:
-      receivers: [hostmetrics]
+      receivers: [datadog/connector, hostmetrics]
       processors: [batch]
-      exporters: [datadog]
+      exporters: [datadog/exporter]
+
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [datadog]
+      exporters: [datadog/connector, datadog/exporter]
+
     logs:
-      receivers: [otlp, filelog]
+      receivers: [otlp]
       processors: [batch]
-      exporters: [datadog]
+      exporters: [datadog/exporter]


### PR DESCRIPTION
New config.yaml based on OpenTelemetry Collector version 0.95.0+ requirements from Datadog Docs: https://docs.datadoghq.com/opentelemetry/guide/migration/#migrate-to-opentelemetry-collector-version-0950